### PR TITLE
Some improvements

### DIFF
--- a/src/main/java/net/t00thpick1/residence/ConfigManager.java
+++ b/src/main/java/net/t00thpick1/residence/ConfigManager.java
@@ -67,4 +67,8 @@ public class ConfigManager {
     public boolean isAutoVert() {
         return config.getBoolean("General.AutoVertResidences", false);
     }
+
+    public boolean useMoveListeners() {
+        return config.getBoolean("General.MovementListeners", true);
+    }
 }

--- a/src/main/java/net/t00thpick1/residence/Residence.java
+++ b/src/main/java/net/t00thpick1/residence/Residence.java
@@ -105,8 +105,6 @@ public class Residence extends JavaPlugin {
         }
 
         getServer().getPluginManager().registerEvents(new StateAssurance(), this);
-        getServer().getPluginManager().registerEvents(new VehicleMoveListener(), this);
-        getServer().getPluginManager().registerEvents(new MoveListener(), this);
         getServer().getPluginManager().registerEvents(new TeleportListener(), this);
         getServer().getPluginManager().registerEvents(new ExplosionListener(), this);
         getServer().getPluginManager().registerEvents(new SpawnListener(), this);
@@ -121,6 +119,10 @@ public class Residence extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlaceListener(), this);
         getServer().getPluginManager().registerEvents(new DestroyListener(), this);
         getServer().getPluginManager().registerEvents(new EndermanPickupListener(), this);
+        if (ConfigManager.getInstance().useMoveListeners()) {
+            getServer().getPluginManager().registerEvents(new VehicleMoveListener(), this);
+            getServer().getPluginManager().registerEvents(new MoveListener(), this);
+        }
         (new BukkitRunnable() {
             public void run() {
                 Player[] p = Residence.getInstance().getServer().getOnlinePlayers();

--- a/src/main/java/net/t00thpick1/residence/Residence.java
+++ b/src/main/java/net/t00thpick1/residence/Residence.java
@@ -82,6 +82,7 @@ public class Residence extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        instance = this;
         File dataFolder = getDataFolder();
         cmanager = new CompatabilityManager();
 

--- a/src/main/java/net/t00thpick1/residence/api/flags/FlagManager.java
+++ b/src/main/java/net/t00thpick1/residence/api/flags/FlagManager.java
@@ -101,7 +101,11 @@ public class FlagManager {
             return;
         }
         validFlags.put(flag.getName(), flag);
-        Residence.getInstance().getServer().getPluginManager().addPermission(flag.getPermission());
+        try {
+            Residence.getInstance().getServer().getPluginManager().addPermission(flag.getPermission());
+        } catch (IllegalArgumentException e) {
+            // The permission was already registered. Ignore the exception.
+        }
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,8 @@ General:
     IgnorePluginSpawns: true
     # This setting will preserve flags on a residence that are not registered (generally flags from third party addons)
     PreserveUnregisteredFlags: true
+    # Enables movement listeners. Disabling it reduces server load but you will not be able to block users from entering residences.
+    MovementListeners: true
 Economy:
     Enabled: true
     Rent:


### PR DESCRIPTION
First commit allows add a try block to catch the exception thrown by Bukkit when a permission was already registered, so admins can reload Residence (for example, to update it using PlugMan on a live server)

Second commits makes movement listeners optional. They're the most computationally-intensive thing packed on Residence and personally I don't let users block anybody from entering their residences, so it's a waste of CPU. They're however enabled by default, being therefore a non-breaking change.
